### PR TITLE
add dockerignore to reduce build context & add dockerfile linter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Exclude version control system files
+.git/
+.gitignore
+
+# Exclude dependency directories
+vendor/
+
+# Exclude IDE/editor configuration files
+.vscode/
+.idea/
+*.code-workspace
+
+# Exclude environment files
+.env
+.env.*
+
+# Exclude Dockerfiles and .dockerignore (optional, if not needed in the image)
+Dockerfile
+.dockerignore
+
+README.md
+
+# Linter
+.golangci.yaml
+
+# Makefile
+Makefile
+
+# Pipeline
+.github/

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ migrations-up:
 
 migrations-down:
 	cd database/migrations && sql-migrate down
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+lint-dockerfile:
+	hadolint Dockerfile


### PR DESCRIPTION
## What has changed?

Add `.dockerignore` file to reduce a build context. Add `Dockerfile` linter to the Makefile

### Has it been tested?

Yes
